### PR TITLE
Make validation observable and occur across all fields

### DIFF
--- a/pk-library/src/main/java/me/brendanweinstein/views/FieldHolder.java
+++ b/pk-library/src/main/java/me/brendanweinstein/views/FieldHolder.java
@@ -272,12 +272,11 @@ public class FieldHolder extends RelativeLayout {
 		@Override
 		public void onCVVEntryComplete() {
 			Log.d(TAG, "onCVVEntryComplete");
-			mCardIcon.flipTo(CardIcon.CardFace.FRONT);
-			FieldHolder.this.requestFocus();
-			// complete
-
-			if (mCompletionListener != null) {
-				mCompletionListener.onValidFormComplete();
+			if (isFieldsValid()) {
+				mCardIcon.flipTo(CardIcon.CardFace.FRONT);
+				if (mCompletionListener != null) {
+					mCompletionListener.onValidFormComplete();
+				}
 			}
 		}
 

--- a/pk-library/src/main/java/me/brendanweinstein/views/FieldHolder.java
+++ b/pk-library/src/main/java/me/brendanweinstein/views/FieldHolder.java
@@ -5,7 +5,10 @@ import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
 import android.content.Context;
+import android.graphics.Color;
+import android.text.Editable;
 import android.text.InputFilter;
+import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -44,6 +47,8 @@ public class FieldHolder extends RelativeLayout {
 	private CardIcon mCardIcon;
 	private LinearLayout mExtraFields;
 	private CompletionListener mCompletionListener;
+
+	private int mOriginalTextColor = Color.BLACK;
 
 	public interface CompletionListener {
 		void onValidFormComplete();
@@ -114,6 +119,37 @@ public class FieldHolder extends RelativeLayout {
 	private void setCardEntryListeners() {
 		mExpirationEditText.setCardEntryListener(mCardEntryListener);
 		mCVVEditText.setCardEntryListener(mCardEntryListener);
+		mCardHolder.getCardField().addTextChangedListener(new TextWatcher() {
+			@Override
+			public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+			}
+
+			@Override
+			public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+			}
+
+			@Override
+			public void afterTextChanged(Editable editable) {
+				// Only reset the color if we're showing the invalid card number color (see CardNumHolder.indicateInvalidCardNum())
+				if (mCardHolder.getCardField().getCurrentTextColor() == Color.RED) {
+					CardType cardType = ValidateCreditCard.getCardType(mCardHolder.getCardField().getText().toString());
+					switch (cardType) {
+						case AMERICAN_EXPRESS:
+							if (editable.length() < AMEX_CARD_LENGTH) {
+								mCardHolder.getCardField().setTextColor(mOriginalTextColor);
+							}
+							break;
+						default:
+							if (editable.length() < NON_AMEX_CARD_LENGTH) {
+								mCardHolder.getCardField().setTextColor(mOriginalTextColor);
+							}
+							break;
+					}
+				}
+			}
+		});
 	}
 
 	private void validateCard() {

--- a/pk-library/src/main/java/me/brendanweinstein/views/FieldHolder.java
+++ b/pk-library/src/main/java/me/brendanweinstein/views/FieldHolder.java
@@ -299,7 +299,18 @@ public class FieldHolder extends RelativeLayout {
 		} else if (mCVVEditText.getText().toString().length() != CVV_MAX_LENGTH) {
 			return false;
 		}
-		return true;
+
+		CardType cardType = ValidateCreditCard.getCardType(mCardHolder.getCardField().getText().toString());
+		if (cardType == CardType.AMERICAN_EXPRESS) {
+			return mCardHolder.getCardField().getText().length() == AMEX_CARD_LENGTH;
+		} else {
+			return mCardHolder.getCardField().getText().length() == NON_AMEX_CARD_LENGTH;
+		}
+	}
+
+	public boolean isValidCard() {
+		long cardNumber = Long.parseLong(mCardHolder.getCardField().getText().toString().replaceAll("\\s", ""));
+		return ValidateCreditCard.isValid(cardNumber);
 	}
 
 	public void setCompletionListener(CompletionListener completionListener) {

--- a/pk-library/src/main/java/me/brendanweinstein/views/FieldHolder.java
+++ b/pk-library/src/main/java/me/brendanweinstein/views/FieldHolder.java
@@ -43,6 +43,12 @@ public class FieldHolder extends RelativeLayout {
 	private CVVEditText mCVVEditText;
 	private CardIcon mCardIcon;
 	private LinearLayout mExtraFields;
+	private CompletionListener mCompletionListener;
+
+	public interface CompletionListener {
+		void onValidFormComplete();
+		void onValidFormBackspace();
+	}
 	
 	public FieldHolder(Context context) {
 		super(context);
@@ -233,6 +239,10 @@ public class FieldHolder extends RelativeLayout {
 			mCardIcon.flipTo(CardIcon.CardFace.FRONT);
 			FieldHolder.this.requestFocus();
 			// complete
+
+			if (mCompletionListener != null) {
+				mCompletionListener.onValidFormComplete();
+			}
 		}
 
 		@Override
@@ -240,6 +250,10 @@ public class FieldHolder extends RelativeLayout {
 			Log.d(TAG, "onBackFromCVV");
 			mExpirationEditText.requestFocus();
 			mCardIcon.flipTo(CardIcon.CardFace.FRONT);
+
+			if (mCompletionListener != null) {
+				mCompletionListener.onValidFormBackspace();
+			}
 		}
 
 	};
@@ -253,4 +267,7 @@ public class FieldHolder extends RelativeLayout {
 		return true;
 	}
 
+	public void setCompletionListener(CompletionListener completionListener) {
+		mCompletionListener = completionListener;
+	}
 }


### PR DESCRIPTION
Useful if, e.g., you need to disable a save button until a valid cc is entered.

Also allows the user to go back and edit anywhere (e.g. an invalid expiration date) and immediately get a callback when that's entered correctly again (instead of having to get to the end of the CVV field).